### PR TITLE
api call tweaks: standardize the screenshot, mhtml and raw dom api calls

### DIFF
--- a/autobrowser/automation/details.py
+++ b/autobrowser/automation/details.py
@@ -182,7 +182,6 @@ class AutomationConfig:
     # configuration details concerning where to send data
     # during the crawl to if we are to send something
     screenshot_api_url: Optional[str] = attr.ib(default=None)
-    screenshot_target_uri: Optional[str] = attr.ib(default=None)
     screenshot_format: Optional[str] = attr.ib(default=None)
     screenshot_dimensions: Optional[Tuple[float, float]] = attr.ib(
         default=None, converter=convert_screenshot_dims
@@ -306,14 +305,6 @@ class AutomationConfig:
         """
         return f"{self.fetch_behavior_info_endpoint}{page_url}"
 
-    def screenshot_endpoint_url(
-        self, reqid: Optional[str] = None, format_: str = "png"
-    ) -> str:
-        if reqid is None:
-            reqid = self.reqid
-        params = f"?reqid={reqid}&target_uri={self.screenshot_target_uri}&content_type=image/{format_}"
-        return f"{self.screenshot_api_url}{params}"
-
     def get(self, key: Any, default: Any = None) -> Any:
         value = self.config_value(key)
         if value is None:
@@ -386,9 +377,6 @@ def build_automation_config(
             "FETCH_BEHAVIOR_INFO_ENDPOINT", default=f"{behavior_api_url}/info?url="
         ),
         screenshot_api_url=env("SCREENSHOT_API_URL"),
-        screenshot_target_uri=env(
-            "SCREENSHOT_TARGET_URI", default="urn:screenshot:{url}"
-        ),
         screenshot_format=env("SCREENSHOT_FORMAT", default="png"),
         screenshot_dimensions=env("SCREENSHOT_DIMENSIONS"),
         extracted_mhtml_api_url=env("EXTRACTED_MHTML_API_URL"),

--- a/autobrowser/tabs/basetab.py
+++ b/autobrowser/tabs/basetab.py
@@ -528,7 +528,7 @@ class BaseTab(Tab):
         :param params: Extra query params for the Request
         :param data: Optional non JSON data
         :param json: Optional json data
-        :param headers: content-type to be used with the data
+        :param content_type: content-type to be used with the data
         """
         params = params or {}
         params['reqid'] = self.config.reqid

--- a/autobrowser/tabs/basetab.py
+++ b/autobrowser/tabs/basetab.py
@@ -327,9 +327,6 @@ class BaseTab(Tab):
         self.logger.info(logged_method, "shutdown complete")
 
     async def post_behavior_run(self) -> None:
-        if not self._timestamp:
-            self._timestamp = await self.evaluate_in_page("window.wbinfo && window.wbinfo.timestamp")
-
         await self.capture_and_upload_screenshot()
         await self.extract_page_data_and_send()
 

--- a/autobrowser/tabs/basetab.py
+++ b/autobrowser/tabs/basetab.py
@@ -519,7 +519,7 @@ class BaseTab(Tab):
         params: Optional[Dict] = None,
         data: Any = None,
         json: Any = None,
-        content_type = 'application/json',
+        content_type: str = 'application/json',
     ) -> None:
         """Uploads the supplied data or json to the supplied URL.
         Method used is PUT


### PR DESCRIPTION
also store 'timestamp' of current page, using either Memento-Datetime or wbinfo.timestamp headers (for api usage)