### PR TITLE
Frontier and scope updates

### DIFF
--- a/autobrowser/behaviors/runners.py
+++ b/autobrowser/behaviors/runners.py
@@ -215,17 +215,13 @@ class WRBehaviorRunner(Behavior):
         Available post run actions:
          - Out link collection
         """
-        logged_method = "post action"
-        self.logger.debug(
-            logged_method, Helper.json_string(action_count=self._num_actions_performed)
-        )
         self._num_actions_performed += 1
         # If the behavior runner is configured to collect out links, the collection occurs after every 10
         # actions initiated. This is done in order to ensure that the performance of running an behavior does
         # not degrade due to a page having lots of out links (10k+).
         # Note: the previous handling of out links was to collect them after every action
         if self.collect_outlinks and self._num_actions_performed % 10 == 0:
-            self.logger.debug(logged_method, f"collecting outlinks")
+            self.logger.debug("post action", f"collecting outlinks")
             await self.tab.collect_outlinks()
 
     async def _post_run(self) -> None:

--- a/autobrowser/frontier/redis.py
+++ b/autobrowser/frontier/redis.py
@@ -195,7 +195,7 @@ class RedisFrontier:
 
         """
         self.crawl_depth = int(
-            await self.redis.hget(self.keys.info, CRAWL_DEPTH_FIELD) or 0
+            await self.redis.hget(self.keys.info, CRAWL_DEPTH_FIELD) or -1
         )
         self.logger.info("init", f"crawl depth = {self.crawl_depth}")
         await self.scope.init()
@@ -259,7 +259,7 @@ class RedisFrontier:
         """
         logged_method = "add_all"
         next_depth = self.next_depth()
-        if next_depth > self.crawl_depth:
+        if self.crawl_depth != -1 and next_depth > self.crawl_depth:
             self.logger.info(
                 logged_method,
                 f"Not adding any URLs, maximum crawl depth exceeded. Max depth = {self.crawl_depth}",

--- a/autobrowser/scope/strict_rules.py
+++ b/autobrowser/scope/strict_rules.py
@@ -1,0 +1,79 @@
+from typing import Optional, Union, AnyStr
+
+from urlcanon import MatchRule, ParsedUrl, parse_url
+
+URL_T = Union[ParsedUrl, AnyStr]
+
+__all__ = ["StrictMatchRule"]
+
+
+class StrictMatchRule(MatchRule):
+    """This subclass of MatchRule adds strict matching as well as lax matching
+    (provided by applies)"""
+
+    def __init__(
+        self,
+        surt: Optional[AnyStr] = None,
+        ssurt: Optional[AnyStr] = None,
+        regex: Optional[AnyStr] = None,
+        domain: Optional[AnyStr] = None,
+        substring: Optional[AnyStr] = None,
+        parent_url_regex: Optional[AnyStr] = None,
+        url_match: Optional[str] = None,
+        value: Optional[str] = None,
+        strict: bool = False,
+    ) -> None:
+        super().__init__(
+            surt=surt,
+            ssurt=ssurt,
+            regex=regex,
+            domain=domain,
+            substring=substring,
+            parent_url_regex=parent_url_regex,
+            url_match=url_match,
+            value=value,
+        )
+        self.strict: bool = strict
+
+    def applies(self, url: URL_T, parent_url: Optional[URL_T] = None) -> bool:
+        if self.strict:
+            return self.applies_strict(url, parent_url)
+        return super().applies(url, parent_url)
+
+    def applies_lax(self, url: URL_T, parent_url: Optional[URL_T] = None) -> bool:
+        return super().applies(url, parent_url)
+
+    def applies_strict(self, url: URL_T, parent_url: Optional[URL_T] = None) -> bool:
+        """Returns true if the supplied URL matches this rules exactly.
+
+        If the rules was created with a 'domain' supplied the host of the supplied
+        URL must match the configured 'domain' exactly, likewise with 'surt' and 'ssurt'.
+
+        :param url: The URL to be tested to determine if it matches against this rules
+        :param parent_url: parent url, should be supplied if the rule has a
+        `parent_url_regex`
+        :return: T/F indicating if the supplied URL matches this rule
+        """
+        if not isinstance(url, ParsedUrl):
+            url = parse_url(url)
+        if self.domain and self.domain != url.host:
+            return False
+        if self.surt and url.surt() != self.surt:
+            return False
+        if self.ssurt and url.ssurt() != self.ssurt:
+            return False
+        if self.substring and url.__bytes__().find(self.substring) == -1:
+            return False
+        if self.regex:
+            if not self.regex.match(url.__bytes__()):
+                return False
+        if self.parent_url_regex:
+            if not parent_url:
+                return False
+            if isinstance(parent_url, ParsedUrl):
+                parent_url = parent_url.__bytes__()
+            elif isinstance(parent_url, str):
+                parent_url = parent_url.encode("utf-8")
+            if not self.parent_url_regex.match(parent_url):
+                return False
+        return True

--- a/autobrowser/tabs/basetab.py
+++ b/autobrowser/tabs/basetab.py
@@ -183,7 +183,7 @@ class BaseTab(Tab):
         await self._reconnect_promise
 
     async def wait_for_net_idle(
-        self, num_inflight: int = 2, idle_time: int = 2, global_wait: int = 60
+        self, num_inflight: int = 2, idle_time: int = 2, global_wait: int = 10
     ) -> None:
         """Returns a future that  resolves once network idle occurs.
 
@@ -489,13 +489,15 @@ class BaseTab(Tab):
                 screen_orientation["angle"] = 90
                 screen_orientation["type"] = "landscapePrimary"
 
-            await self.client.send(
-                "Emulation.setTouchEmulationEnabled",
-                {
-                    "enabled": device.get("hasTouch", False),
-                    "maxTouchPoints": device.get("maxTouchPoints", 1),
-                },
-            )
+            has_touch = device.get("hasTouch")
+            if has_touch is not None:
+                await self.client.send(
+                    "Emulation.setTouchEmulationEnabled",
+                    {
+                        "enabled": has_touch or False,
+                        "maxTouchPoints": device.get("maxTouchPoints", 1),
+                    },
+                )
             self._viewport = {
                 "mobile": device.get("isMobile", False),
                 "width": device["width"],


### PR DESCRIPTION
REF: https://github.com/webrecorder/browsertrix/pull/31

scope:
  - added strict matching rules in order to ensure that the same domain crawl works as expected
  - strip the www. if it exists on any URL to be tested if it is in scope

frontier:
  - do not check depth if the crawl depth is -1 (no limit)

tabs:
  - decreased the network idle wait from a full minute to 10 seconds